### PR TITLE
Modernize project: iOS 15, NSSecureCoding, strong refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             xcrun --sdk iphonesimulator clang \
               -arch arm64 \
               -isysroot "$SDK_PATH" \
-              -mios-simulator-version-min=12.0 \
+              -mios-simulator-version-min=15.0 \
               -fobjc-arc \
               -fmodules \
               -Wall \

--- a/Classes/YCFirstTimeObject.h
+++ b/Classes/YCFirstTimeObject.h
@@ -11,16 +11,16 @@
 /*!
  *  A model class to support YCFirstTime class.
  */
-@interface YCFirstTimeObject : NSObject
+@interface YCFirstTimeObject : NSObject <NSSecureCoding>
 
 /*!
  *  The last version that a snippet was executed.
  */
-@property (nonatomic, retain) NSString *lastVersion;
+@property (nonatomic, strong) NSString *lastVersion;
 
 /*!
  *  The last time that a snippet was executed.
  */
-@property (nonatomic, retain) NSDate *lastTime;
+@property (nonatomic, strong) NSDate *lastTime;
 
 @end

--- a/Classes/YCFirstTimeObject.m
+++ b/Classes/YCFirstTimeObject.m
@@ -13,6 +13,11 @@
  */
 @implementation YCFirstTimeObject
 
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
 /*!
  *  Returns an object initialized from data in a given unarchiver.
  *  @param coder An unarchiver object.
@@ -23,12 +28,12 @@
     if ((self = [super init]))
     {
         /// The last version that a snippet was executed.
-        _lastVersion = [coder decodeObjectForKey:@"lastVersion"];
-        
+        _lastVersion = [coder decodeObjectOfClass:[NSString class] forKey:@"lastVersion"];
+
         /// The last time that a snippet was executed.
-        _lastTime = [coder decodeObjectForKey:@"lastTime"];
+        _lastTime = [coder decodeObjectOfClass:[NSDate class] forKey:@"lastTime"];
     }
-    
+
     return self;
 }
 

--- a/YCFirstTime.m
+++ b/YCFirstTime.m
@@ -17,7 +17,7 @@
 /*!
  *  The NSMutableDictionary to persist the block execution history.
  */
-@property (nonatomic, retain) NSMutableDictionary *fkDict;
+@property (nonatomic, strong) NSMutableDictionary *fkDict;
 
 @end
 
@@ -294,7 +294,17 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     NSData *encodedDictionary = [userDefaults objectForKey:NSStringFromClass([self class])];
     if (encodedDictionary) {
-        return [NSKeyedUnarchiver unarchiveObjectWithData:encodedDictionary];
+        NSSet *allowed = [NSSet setWithArray:@[
+            [NSMutableDictionary class],
+            [NSDictionary class],
+            [NSString class],
+            [NSDate class],
+            [YCFirstTimeObject class],
+        ]];
+        NSMutableDictionary *decoded = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowed
+                                                                           fromData:encodedDictionary
+                                                                              error:nil];
+        return decoded ?: [NSMutableDictionary dictionary];
     } else {
         return [NSMutableDictionary dictionary];
     }
@@ -306,9 +316,12 @@
 - (void)saveDictionaryToUserDefaults;
 {
     /// Encodes and Saves the decoded running dictionary to User Defaults.
-    NSData *decodedDictionary = [NSKeyedArchiver archivedDataWithRootObject:self.fkDict];
-    [[NSUserDefaults standardUserDefaults] setObject:decodedDictionary forKey:NSStringFromClass([self class])];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSData *decodedDictionary = [NSKeyedArchiver archivedDataWithRootObject:self.fkDict
+                                                      requiringSecureCoding:YES
+                                                                      error:nil];
+    if (decodedDictionary) {
+        [[NSUserDefaults standardUserDefaults] setObject:decodedDictionary forKey:NSStringFromClass([self class])];
+    }
 }
 
 @end

--- a/YCFirstTime.podspec
+++ b/YCFirstTime.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'YCFirstTime'
-  spec.version          = '1.1.4'
+  spec.version          = '1.2.0'
   spec.license          = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage         = 'https://github.com/yuppiu/YCFirstTime'
   spec.authors          = { 'Fabio Knoedt' => 'fabioknoedt@gmail.com' }
@@ -8,5 +8,5 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => 'https://github.com/yuppiu/YCFirstTime.git', :tag => spec.version.to_s }
   spec.source_files     = 'YCFirstTime.{h,m}', 'Classes/*.{h,m}'
   spec.requires_arc     = true
-  spec.ios.deployment_target = '12.0'
+  spec.ios.deployment_target = '15.0'
 end


### PR DESCRIPTION
- Bump spec.ios.deployment_target from 12.0 to 15.0
- Bump pod version 1.1.4 -> 1.2.0
- Adopt NSSecureCoding in YCFirstTimeObject
- Replace deprecated NSKeyedArchiver/NSKeyedUnarchiver APIs with their
  secure-coding equivalents (deprecated since iOS 12)
- Replace @property (retain) with (strong)
- Drop redundant [NSUserDefaults synchronize] call (no-op on modern iOS)
- Align direct-clang CI job min version with podspec