### PR TITLE
Add XCTest suite to pin down behavior before Swift migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pod-lint:
-    name: Pod lib lint
+    name: Pod lib lint + tests
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,8 +18,27 @@ jobs:
           pod --version
 
       - name: Lint podspec and run test_spec
-        # `pod lib lint` runs the test_spec by default (use --skip-tests to opt out).
-        run: pod lib lint YCFirstTime.podspec --allow-warnings --verbose
+        # `pod lib lint` runs the test_spec by default. We tee the output so
+        # the follow-up step can verify tests actually executed — a missing
+        # test_spec would otherwise pass lint silently.
+        run: |
+          set -o pipefail
+          pod lib lint YCFirstTime.podspec --allow-warnings --verbose 2>&1 \
+            | tee /tmp/pod-lint.log
+
+      - name: Verify test_spec executed and passed
+        run: |
+          set -e
+          if ! grep -qE "Test Suite '.*YCFirstTimeTests'.*passed" /tmp/pod-lint.log; then
+            echo "::error::YCFirstTimeTests did not run or did not pass."
+            echo "Expected an xcodebuild 'Test Suite ... passed' line for YCFirstTimeTests."
+            exit 1
+          fi
+          if ! grep -qE "Test Suite '.*YCFirstTimeObjectTests'.*passed" /tmp/pod-lint.log; then
+            echo "::error::YCFirstTimeObjectTests did not run or did not pass."
+            exit 1
+          fi
+          echo "All XCTest suites ran and passed."
 
   compile:
     name: Compile sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
           xcodebuild -version
           pod --version
 
-      - name: Lint podspec
+      - name: Lint podspec and run test_spec
+        # `pod lib lint` runs the test_spec by default (use --skip-tests to opt out).
         run: pod lib lint YCFirstTime.podspec --allow-warnings --verbose
 
   compile:

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XCTest
+import YCFirstTime
+
+/// The UserDefaults key under which YCFirstTime stores its archived dictionary
+/// (= NSStringFromClass([YCFirstTime class])).
+let kYCFirstTimeDefaultsKey = "YCFirstTime"
+
+/// The hardcoded sharedGroup constant from YCFirstTime.m. The buggy -reset
+/// removes a key with this name, so tests clear it too.
+let kYCFirstTimeSharedGroupKey = "sharedGroup"
+
+enum TestDefaults {
+    /// Wipe all persisted state used by YCFirstTime so each test starts clean.
+    static func clear() {
+        UserDefaults.standard.removeObject(forKey: kYCFirstTimeDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: kYCFirstTimeSharedGroupKey)
+        UserDefaults.standard.synchronize()
+    }
+}
+
+extension YCFirstTime {
+    /// Convenience for tests — build a fresh instance with fixed version + clock.
+    static func makeForTest(version: String, now: Date = Date()) -> YCFirstTime {
+        let instance = YCFirstTime.newInstanceForTesting()
+        var mutableNow = now
+        instance.versionProvider = { version }
+        instance.nowProvider = { mutableNow }
+        return instance
+    }
+}

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -1,6 +1,5 @@
 import Foundation
 import XCTest
-import YCFirstTime
 
 /// The UserDefaults key under which YCFirstTime stores its archived dictionary
 /// (= NSStringFromClass([YCFirstTime class])).
@@ -22,10 +21,9 @@ enum TestDefaults {
 extension YCFirstTime {
     /// Convenience for tests — build a fresh instance with fixed version + clock.
     static func makeForTest(version: String, now: Date = Date()) -> YCFirstTime {
-        let instance = YCFirstTime.newInstanceForTesting()
-        var mutableNow = now
+        let instance = YCFirstTime.makeTestInstance()
         instance.versionProvider = { version }
-        instance.nowProvider = { mutableNow }
+        instance.nowProvider = { now }
         return instance
     }
 }

--- a/Tests/YCFirstTime+Testing.h
+++ b/Tests/YCFirstTime+Testing.h
@@ -1,0 +1,25 @@
+//
+//  YCFirstTime+Testing.h
+//  Test-only category — NOT shipped in the pod (excluded by podspec source_files).
+//
+//  Exposes the seams declared privately in YCFirstTime.m so Swift XCTest
+//  suites can inject a deterministic version string and clock, and construct
+//  fresh instances isolated from the +shared singleton.
+//
+
+#import "YCFirstTime.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface YCFirstTime (Testing)
+
+@property (nonatomic, copy, nullable) NSString *(^versionProvider)(void);
+@property (nonatomic, copy, nullable) NSDate *(^nowProvider)(void);
+
+/// Construct a fresh instance that loads from UserDefaults, bypassing +shared.
+/// Each call returns a new object.
++ (instancetype)newInstanceForTesting;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/YCFirstTime+Testing.h
+++ b/Tests/YCFirstTime+Testing.h
@@ -13,12 +13,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YCFirstTime (Testing)
 
+/// Overrides the source for the current version string. Pass nil to restore
+/// the default CFBundleShortVersionString lookup. Backed by storage declared
+/// in the class extension inside YCFirstTime.m — the category itself declares
+/// @dynamic to suppress a redundant synthesis.
 @property (nonatomic, copy, nullable) NSString *(^versionProvider)(void);
+
+/// Overrides the source for the current date. Pass nil to restore
+/// +[NSDate date]. Same storage caveat as versionProvider.
 @property (nonatomic, copy, nullable) NSDate *(^nowProvider)(void);
 
 /// Construct a fresh instance that loads from UserDefaults, bypassing +shared.
-/// Each call returns a new object.
-+ (instancetype)newInstanceForTesting;
+/// Each call returns a new object. Named `makeTestInstance` rather than
+/// `newInstanceForTesting` to avoid the `new` prefix, which Swift's Obj-C
+/// importer treats specially (NS_RETURNS_RETAINED semantics).
++ (instancetype)makeTestInstance;
 
 @end
 

--- a/Tests/YCFirstTime+Testing.m
+++ b/Tests/YCFirstTime+Testing.m
@@ -6,7 +6,13 @@
 
 @implementation YCFirstTime (Testing)
 
-+ (instancetype)newInstanceForTesting
+// Accessors are synthesized by the class extension in YCFirstTime.m. Declaring
+// them @dynamic here prevents the category from trying to re-synthesize and
+// tells the compiler the implementation is provided elsewhere.
+@dynamic versionProvider;
+@dynamic nowProvider;
+
++ (instancetype)makeTestInstance
 {
     return [[self alloc] init];
 }

--- a/Tests/YCFirstTime+Testing.m
+++ b/Tests/YCFirstTime+Testing.m
@@ -1,0 +1,14 @@
+//
+//  YCFirstTime+Testing.m
+//
+
+#import "YCFirstTime+Testing.h"
+
+@implementation YCFirstTime (Testing)
+
++ (instancetype)newInstanceForTesting
+{
+    return [[self alloc] init];
+}
+
+@end

--- a/Tests/YCFirstTimeObjectTests.swift
+++ b/Tests/YCFirstTimeObjectTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import YCFirstTime
+
+final class YCFirstTimeObjectTests: XCTestCase {
+
+    func test_supportsSecureCoding() {
+        XCTAssertTrue(YCFirstTimeObject.supportsSecureCoding)
+    }
+
+    func test_encodeDecodePreservesFields() throws {
+        let original = YCFirstTimeObject()
+        original.lastVersion = "1.2.3"
+        original.lastTime = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let data = try NSKeyedArchiver.archivedData(
+            withRootObject: original,
+            requiringSecureCoding: true
+        )
+        let decoded = try XCTUnwrap(
+            NSKeyedUnarchiver.unarchivedObject(ofClass: YCFirstTimeObject.self, from: data)
+        )
+
+        XCTAssertEqual(decoded.lastVersion, "1.2.3")
+        XCTAssertEqual(decoded.lastTime, Date(timeIntervalSince1970: 1_700_000_000))
+    }
+}

--- a/Tests/YCFirstTimeObjectTests.swift
+++ b/Tests/YCFirstTimeObjectTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import YCFirstTime
 
 final class YCFirstTimeObjectTests: XCTestCase {
 

--- a/Tests/YCFirstTimeTests-Bridging-Header.h
+++ b/Tests/YCFirstTimeTests-Bridging-Header.h
@@ -5,4 +5,6 @@
 //  this up via SWIFT_OBJC_BRIDGING_HEADER (pod_target_xcconfig below).
 //
 
+#import "YCFirstTime.h"
+#import "YCFirstTimeObject.h"
 #import "YCFirstTime+Testing.h"

--- a/Tests/YCFirstTimeTests-Bridging-Header.h
+++ b/Tests/YCFirstTimeTests-Bridging-Header.h
@@ -1,0 +1,8 @@
+//
+//  YCFirstTimeTests-Bridging-Header.h
+//
+//  Exposes Obj-C headers to Swift XCTest targets. CocoaPods test_spec picks
+//  this up via SWIFT_OBJC_BRIDGING_HEADER (pod_target_xcconfig below).
+//
+
+#import "YCFirstTime+Testing.h"

--- a/Tests/YCFirstTimeTests.swift
+++ b/Tests/YCFirstTimeTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+import YCFirstTime
+
+/// Behavioral pin-down tests for YCFirstTime. These tests exist to give us
+/// confidence when rewriting the library in Swift — the same suite must pass
+/// against both implementations.
+final class YCFirstTimeTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        TestDefaults.clear()
+    }
+
+    override func tearDown() {
+        TestDefaults.clear()
+        super.tearDown()
+    }
+
+    // MARK: - executeOnce:forKey:
+
+    func test_executeOnce_runsOnFirstCallOnly() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        var count = 0
+
+        sut.executeOnce({ count += 1 }, forKey: "k")
+        sut.executeOnce({ count += 1 }, forKey: "k")
+        sut.executeOnce({ count += 1 }, forKey: "k")
+
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_executeOnce_differentKeysAreIndependent() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        var a = 0, b = 0
+
+        sut.executeOnce({ a += 1 }, forKey: "a")
+        sut.executeOnce({ b += 1 }, forKey: "b")
+        sut.executeOnce({ a += 1 }, forKey: "a")
+
+        XCTAssertEqual(a, 1)
+        XCTAssertEqual(b, 1)
+    }
+
+    func test_blockWasExecuted_reflectsState() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+
+        XCTAssertFalse(sut.blockWasExecuted("k"))
+        sut.executeOnce({}, forKey: "k")
+        XCTAssertTrue(sut.blockWasExecuted("k"))
+    }
+
+    func test_executeOnce_nilBlockDoesNotMarkExecuted() {
+        // Pins current behavior at YCFirstTime.m:142 — a nil block is a no-op
+        // and does NOT flip the executed flag.
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+
+        sut.executeOnce(nil, forKey: "k")
+
+        XCTAssertFalse(sut.blockWasExecuted("k"))
+    }
+
+    // MARK: - executeOnce:executeAfterFirstTime:forKey:
+
+    func test_executeAfterFirstTime_runsOnSubsequentCallsOnly() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        var first = 0, after = 0
+
+        sut.executeOnce({ first += 1 }, executeAfterFirstTime: { after += 1 }, forKey: "k")
+        XCTAssertEqual(first, 1)
+        XCTAssertEqual(after, 0)
+
+        sut.executeOnce({ first += 1 }, executeAfterFirstTime: { after += 1 }, forKey: "k")
+        sut.executeOnce({ first += 1 }, executeAfterFirstTime: { after += 1 }, forKey: "k")
+        XCTAssertEqual(first, 1)
+        XCTAssertEqual(after, 2)
+    }
+
+    func test_executeAfterFirstTime_nilAfterBlockIsSilent() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        sut.executeOnce({}, executeAfterFirstTime: nil, forKey: "k")
+        sut.executeOnce({}, executeAfterFirstTime: nil, forKey: "k") // must not crash
+    }
+
+    // MARK: - executeOncePerVersion
+
+    func test_executeOncePerVersion_runsOnceUntilVersionChanges() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        var count = 0
+
+        sut.executeOncePerVersion({ count += 1 }, forKey: "k")
+        sut.executeOncePerVersion({ count += 1 }, forKey: "k")
+        XCTAssertEqual(count, 1)
+
+        sut.versionProvider = { "1.1" }
+        sut.executeOncePerVersion({ count += 1 }, forKey: "k")
+        XCTAssertEqual(count, 2)
+
+        sut.executeOncePerVersion({ count += 1 }, forKey: "k")
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_executeOncePerVersion_usesExactStringEquality() {
+        // Pins current behavior at YCFirstTime.m:187 — "1.0" and "1.0.0" are
+        // different. A Swift port should preserve this unless we decide to
+        // change it deliberately.
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        var count = 0
+
+        sut.executeOncePerVersion({ count += 1 }, forKey: "k")
+        sut.versionProvider = { "1.0.0" }
+        sut.executeOncePerVersion({ count += 1 }, forKey: "k")
+
+        XCTAssertEqual(count, 2)
+    }
+
+    // MARK: - executeOncePerInterval
+
+    func test_executeOncePerInterval_runsAgainAfterInterval() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        var now = start
+        let sut = YCFirstTime.newInstanceForTesting()
+        sut.versionProvider = { "1.0" }
+        sut.nowProvider = { now }
+
+        var count = 0
+        sut.executeOncePerInterval({ count += 1 }, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(count, 1)
+
+        // Same instant — should not run.
+        sut.executeOncePerInterval({ count += 1 }, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(count, 1)
+
+        // Two days later — should run.
+        now = start.addingTimeInterval(2 * 86_400)
+        sut.executeOncePerInterval({ count += 1 }, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_executeOncePerInterval_divisorBugUses84600() {
+        // KNOWN BUG (YCFirstTime.m:194): divisor is 84600, not 86400.
+        // A day is therefore 84_600s in the current impl. An elapsed time
+        // between 84_600 and 86_400 crosses the boundary and triggers a
+        // re-run, even though a real day has not yet passed.
+        //
+        // TODO(swift-port): fix to 86_400 and flip this assertion.
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        var now = start
+        let sut = YCFirstTime.newInstanceForTesting()
+        sut.versionProvider = { "1.0" }
+        sut.nowProvider = { now }
+
+        var count = 0
+        sut.executeOncePerInterval({ count += 1 }, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(count, 1)
+
+        // 85_000 seconds is < 1 real day but > 84_600 (the buggy divisor).
+        now = start.addingTimeInterval(85_000)
+        sut.executeOncePerInterval({ count += 1 }, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(count, 2, "Current impl treats 85_000s as >=1 day due to /84600 bug")
+    }
+
+    // MARK: - blockWasExecuted
+
+    func test_blockWasExecuted_ignoresVersionAndInterval() {
+        // YCFirstTime.m:157 always passes perVersion:FALSE, days:0.
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+
+        sut.executeOncePerVersion({}, forKey: "k")
+        XCTAssertTrue(sut.blockWasExecuted("k"))
+
+        sut.versionProvider = { "2.0" } // would re-run executeOncePerVersion
+        XCTAssertTrue(sut.blockWasExecuted("k"), "blockWasExecuted must not consider version")
+    }
+
+    // MARK: - reset
+
+    func test_reset_clearsInMemoryState() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        sut.executeOnce({}, forKey: "k")
+        XCTAssertTrue(sut.blockWasExecuted("k"))
+
+        sut.reset()
+
+        XCTAssertFalse(sut.blockWasExecuted("k"))
+    }
+
+    func test_reset_doesNotClearPersistedStateDueToBug() {
+        // KNOWN BUG (YCFirstTime.m:281): -reset removes the "sharedGroup" key,
+        // but the archive is persisted under the class-name key "YCFirstTime".
+        // So a relaunch resurrects the "reset" state.
+        //
+        // TODO(swift-port): remove the correct key and flip this assertion.
+        let first = YCFirstTime.makeForTest(version: "1.0")
+        first.executeOnce({}, forKey: "k")
+        first.reset()
+
+        let secondAfterRelaunch = YCFirstTime.makeForTest(version: "1.0")
+        XCTAssertTrue(
+            secondAfterRelaunch.blockWasExecuted("k"),
+            "Current impl persists through reset due to wrong-key bug"
+        )
+    }
+
+    // MARK: - Singleton
+
+    func test_shared_returnsSameInstance() {
+        XCTAssertTrue(YCFirstTime.shared() === YCFirstTime.shared())
+    }
+
+    // MARK: - Persistence format (migration contract)
+
+    func test_persistence_roundTripsThroughUserDefaults() {
+        let writer = YCFirstTime.makeForTest(version: "1.0")
+        writer.executeOnce({}, forKey: "seen-onboarding")
+        writer.executeOncePerVersion({}, forKey: "changelog")
+
+        // Fresh instance reloads from disk.
+        let reader = YCFirstTime.makeForTest(version: "1.0")
+        XCTAssertTrue(reader.blockWasExecuted("seen-onboarding"))
+        XCTAssertTrue(reader.blockWasExecuted("changelog"))
+    }
+
+    func test_persistence_archiveShapeIsSharedGroupDict() {
+        // Pins the on-disk layout that a Swift port must be able to decode
+        // for installed users to keep their "already seen" state.
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        sut.executeOnce({}, forKey: "k")
+
+        guard let data = UserDefaults.standard.data(forKey: kYCFirstTimeDefaultsKey) else {
+            return XCTFail("No archive persisted")
+        }
+        let allowed: Set<AnyHashable> = [
+            NSMutableDictionary.self, NSDictionary.self,
+            NSString.self, NSDate.self, YCFirstTimeObject.self,
+        ] as Set<AnyHashable>
+        let decoded = try? NSKeyedUnarchiver.unarchivedObject(
+            ofClasses: Array(allowed) as! [AnyClass],
+            from: data
+        ) as? NSDictionary
+
+        XCTAssertNotNil(decoded)
+        let group = decoded?["sharedGroup"] as? NSDictionary
+        XCTAssertNotNil(group, "Archive top-level must contain 'sharedGroup' key")
+        XCTAssertTrue(group?["k"] is YCFirstTimeObject)
+    }
+}

--- a/Tests/YCFirstTimeTests.swift
+++ b/Tests/YCFirstTimeTests.swift
@@ -232,13 +232,17 @@ final class YCFirstTimeTests: XCTestCase {
             NSMutableDictionary.self, NSDictionary.self,
             NSString.self, NSDate.self, YCFirstTimeObject.self,
         ]
-        let decoded = try? NSKeyedUnarchiver.unarchivedObject(
+        let decoded = (try? NSKeyedUnarchiver.unarchivedObject(
             ofClasses: allowed, from: data
-        ) as? NSDictionary
+        )) as? NSDictionary
 
-        XCTAssertNotNil(decoded)
-        let group = decoded?["sharedGroup"] as? NSDictionary
-        XCTAssertNotNil(group, "Archive top-level must contain 'sharedGroup' key")
-        XCTAssertTrue(group?["k"] is YCFirstTimeObject)
+        guard let decoded else {
+            return XCTFail("Archive did not decode into an NSDictionary")
+        }
+        guard let group = decoded["sharedGroup"] as? NSDictionary else {
+            return XCTFail("Archive top-level must contain 'sharedGroup' key")
+        }
+        XCTAssertNotNil(group["k"] as? YCFirstTimeObject,
+                        "'sharedGroup' must map block key to YCFirstTimeObject")
     }
 }

--- a/Tests/YCFirstTimeTests.swift
+++ b/Tests/YCFirstTimeTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import YCFirstTime
 
 /// Behavioral pin-down tests for YCFirstTime. These tests exist to give us
 /// confidence when rewriting the library in Swift — the same suite must pass
@@ -118,7 +117,7 @@ final class YCFirstTimeTests: XCTestCase {
     func test_executeOncePerInterval_runsAgainAfterInterval() {
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         var now = start
-        let sut = YCFirstTime.newInstanceForTesting()
+        let sut = YCFirstTime.makeTestInstance()
         sut.versionProvider = { "1.0" }
         sut.nowProvider = { now }
 
@@ -145,7 +144,7 @@ final class YCFirstTimeTests: XCTestCase {
         // TODO(swift-port): fix to 86_400 and flip this assertion.
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         var now = start
-        let sut = YCFirstTime.newInstanceForTesting()
+        let sut = YCFirstTime.makeTestInstance()
         sut.versionProvider = { "1.0" }
         sut.nowProvider = { now }
 
@@ -229,13 +228,12 @@ final class YCFirstTimeTests: XCTestCase {
         guard let data = UserDefaults.standard.data(forKey: kYCFirstTimeDefaultsKey) else {
             return XCTFail("No archive persisted")
         }
-        let allowed: Set<AnyHashable> = [
+        let allowed: [AnyClass] = [
             NSMutableDictionary.self, NSDictionary.self,
             NSString.self, NSDate.self, YCFirstTimeObject.self,
-        ] as Set<AnyHashable>
+        ]
         let decoded = try? NSKeyedUnarchiver.unarchivedObject(
-            ofClasses: Array(allowed) as! [AnyClass],
-            from: data
+            ofClasses: allowed, from: data
         ) as? NSDictionary
 
         XCTAssertNotNil(decoded)

--- a/YCFirstTime.m
+++ b/YCFirstTime.m
@@ -19,6 +19,18 @@
  */
 @property (nonatomic, strong) NSMutableDictionary *fkDict;
 
+/*!
+ *  Injectable provider for the current app version string. Tests override this
+ *  via the YCFirstTime+Testing category. Defaults to CFBundleShortVersionString.
+ */
+@property (nonatomic, copy) NSString *(^versionProvider)(void);
+
+/*!
+ *  Injectable provider for the current date. Tests override this via the
+ *  YCFirstTime+Testing category. Defaults to [NSDate date].
+ */
+@property (nonatomic, copy) NSDate *(^nowProvider)(void);
+
 @end
 
 /*!
@@ -38,6 +50,14 @@
         
         /// Load the already tracked executed blocks from UserDefaults.
         self.fkDict = [self loadDictionaryFromUserDefaults];
+
+        /// Default providers — overridable via YCFirstTime+Testing.
+        self.versionProvider = ^NSString *{
+            return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+        };
+        self.nowProvider = ^NSDate *{
+            return [NSDate date];
+        };
     }
     
     return self;
@@ -183,14 +203,15 @@
     /// Version.
     if (checkVersion && blockInfo) {
         
-        NSString *currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+        NSString *currentVersion = self.versionProvider ? self.versionProvider() : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         executed = executed && [currentVersion isEqualToString:blockInfo.lastVersion];
     }
     
     /// Every X days.
     if (days && blockInfo) {
         
-        float differenceInSeconds = [[NSDate date] timeIntervalSinceDate:blockInfo.lastTime];
+        NSDate *now = self.nowProvider ? self.nowProvider() : [NSDate date];
+        float differenceInSeconds = [now timeIntervalSinceDate:blockInfo.lastTime];
         executed = executed && differenceInSeconds/84600 < days;
     }
     
@@ -211,10 +232,10 @@
     }
     
     /// Set the version.
-    blockInfo.lastVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    
+    blockInfo.lastVersion = self.versionProvider ? self.versionProvider() : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+
     /// Set last time execute date.
-    blockInfo.lastTime = [NSDate date];
+    blockInfo.lastTime = self.nowProvider ? self.nowProvider() : [NSDate date];
     
     /// Set to the main dictionary.
     [self setInfoForBlock:blockInfo forKey:blockKey forGroup:groupKey];

--- a/YCFirstTime.podspec
+++ b/YCFirstTime.podspec
@@ -9,4 +9,13 @@ Pod::Spec.new do |spec|
   spec.source_files     = 'YCFirstTime.{h,m}', 'Classes/*.{h,m}'
   spec.requires_arc     = true
   spec.ios.deployment_target = '15.0'
+
+  spec.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.{h,m,swift}'
+    test_spec.requires_app_host = true
+    test_spec.pod_target_xcconfig = {
+      'SWIFT_OBJC_BRIDGING_HEADER' => '${PODS_TARGET_SRCROOT}/Tests/YCFirstTimeTests-Bridging-Header.h',
+      'SWIFT_VERSION' => '5.0'
+    }
+  end
 end


### PR DESCRIPTION
Establishes a behavioral safety net so the library can be rewritten in
Swift with confidence that observable semantics and on-disk persistence
format are preserved.

- Add versionProvider / nowProvider seams to YCFirstTime (private
  properties on the class extension, exposed to tests via a new
  YCFirstTime+Testing category). No change to public API.
- Add Swift XCTest cases covering executeOnce, executeAfterFirstTime,
  executeOncePerVersion, executeOncePerInterval, blockWasExecuted,
  reset, singleton identity, and the NSKeyedArchiver persistence shape.
- Document two known bugs with dedicated tests marked as
  swift-port fix targets: /84600 divisor (YCFirstTime.m:194) and
  reset removing the wrong UserDefaults key (YCFirstTime.m:281).
- Wire a test_spec into the podspec and point CI's pod lib lint at it.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK