### PR TITLE
Add .spi.yml so Swift Package Index hosts DocC for iOS

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,7 @@
+# Swift Package Index build + documentation configuration.
+# Docs: https://swiftpackageindex.com/swiftpackageindex/spimanifest/documentation
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [YCFirstTime]


### PR DESCRIPTION
Swift Package Index auto-builds and hosts documentation for any
package that declares a target list. Without this file SPI uses
defaults that usually still work, but declaring the iOS platform and
the documentation target explicitly avoids building docs on the wrong
platform and makes the hosted docs link directly to YCFirstTime's
DocC catalog (Sources/YCFirstTime/YCFirstTime.docc/).

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK