### PR TITLE
Pass CODECOV_TOKEN and fail loudly on upload errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,25 @@ jobs:
             -instr-profile "$PROF" \
             -ignore-filename-regex='\.build|Tests|Examples' \
             "$BIN" > coverage.lcov
+          echo "coverage.lcov: $(wc -c < coverage.lcov) bytes, $(wc -l < coverage.lcov) lines"
+
+      - name: Upload coverage as workflow artifact
+        # Lets us download and inspect coverage.lcov from the run, independent
+        # of whether the Codecov upload below succeeds.
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage.lcov
+          if-no-files-found: error
 
       - name: Upload coverage to Codecov
+        # Codecov v4 requires a repository upload token for pushes to
+        # protected branches. `fail_ci_if_error: true` so a silent upload
+        # failure turns the job red instead of passing with no coverage.
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.lcov
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          verbose: true
 


### PR DESCRIPTION
The Swift Package Manager test job was silently failing to upload coverage: Codecov v4 rejected pushes to protected branches with "token required". Because `fail_ci_if_error: false`, the job stayed green and the Codecov dashboard stayed empty.

- Thread the token through from the CODECOV_TOKEN repo secret (user must add this via repo Settings → Secrets → Actions).
- Flip `fail_ci_if_error: true` so a future silent failure turns the job red.
- Enable `verbose: true` so any failure prints diagnostic context.
- Emit the coverage.lcov byte/line count after export.
- Upload coverage.lcov as a workflow artifact so we can download and inspect it independent of the Codecov side.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK

<!--
Keep this PR focused. Unrelated cleanup belongs in a separate PR.
-->

## Summary

<!-- 1–3 bullets: what this changes and why. -->

## Changes

<!-- Bulleted list of the notable diffs. -->

## Test plan

<!--
How did you verify this?
- [ ] `swift test` passes locally
- [ ] `pod lib lint YCFirstTime.podspec --allow-warnings` passes
- [ ] Added / updated tests
- [ ] Updated `///` doc comments for any changed public symbol
- [ ] Added a `CHANGELOG.md` entry under `[Unreleased]`
-->

## Persistence contract

<!--
Does this PR change any of:
- UserDefaults key ("YCFirstTime")
- sharedGroup constant
- YCFirstTimeObject class name
- "lastVersion" / "lastTime" coder keys

If yes, describe the migration plan. If no, delete this section.
-->
