### PR TITLE
Bump GitHub Actions to Node 24-compatible versions (closes #14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Pod lib lint + tests
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Show environment
         run: |
@@ -44,7 +44,7 @@ jobs:
     name: Swift Package Manager test
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: swift test with coverage
         # Serial on purpose — see note in the claude/docc-examples branch.
@@ -68,17 +68,18 @@ jobs:
       - name: Upload coverage as workflow artifact
         # Lets us download and inspect coverage.lcov from the run, independent
         # of whether the Codecov upload below succeeds.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-lcov
           path: coverage.lcov
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        # Codecov v4 requires a repository upload token for pushes to
-        # protected branches. `fail_ci_if_error: true` so a silent upload
-        # failure turns the job red instead of passing with no coverage.
-        uses: codecov/codecov-action@v4
+        # Codecov v5 runs on Node 24. The v4 behavior around protected-branch
+        # uploads still applies — the repository upload token is required.
+        # `fail_ci_if_error: true` so a silent upload failure turns the job
+        # red instead of passing with no coverage.
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.lcov


### PR DESCRIPTION
GitHub deprecated Node.js 20 action runners; it becomes the forced
default on June 2, 2026 and is removed entirely on September 16, 2026.
The warnings surfaced in the CI run linked from issue #14 came from:

- actions/checkout@v4       (runs on Node 20)
- actions/upload-artifact@v4 (runs on Node 20)
- codecov/codecov-action@v4 (runs on Node 20)

All three have v5 releases that run on Node 24. The inputs we pass
(token / files / fail_ci_if_error / verbose for codecov; name / path /
if-no-files-found for upload-artifact) are unchanged.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK