### PR TITLE
Add lastExecutionDate(forKey:) read-only accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- `lastExecutionDate(forKey:) -> Date?` — read-only accessor for the timestamp
+  of a key's most recent successful execution. The library already stores this
+  for interval math; exposing it means apps that display "last asked N days
+  ago" don't need to track it twice. `@objc` selector:
+  `-[YCFirstTime lastExecutionDateForKey:]`.
+
 ## [2.0.0] — 2026-04-19
 
 Swift rewrite. Public API and on-disk archive format are preserved, so

--- a/Examples/09-last-execution-date.swift
+++ b/Examples/09-last-execution-date.swift
@@ -1,0 +1,17 @@
+// Display "last asked N days ago" for a rate-limited prompt.
+//
+// `lastExecutionDate(forKey:)` returns the stored timestamp of the most
+// recent successful execution, or nil if the key has never run. It's a
+// pure read — calling it does not mark anything as executed.
+
+import Foundation
+import YCFirstTime
+
+func describeRatingPromptRecency() -> String {
+    guard let lastAsked = YCFirstTime.shared.lastExecutionDate(forKey: "prompt.rating") else {
+        return "Never asked."
+    }
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .full
+    return "Last asked \(formatter.localizedString(for: lastAsked, relativeTo: Date()))"
+}

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -13,3 +13,4 @@ Swift — drop it into any iOS 15+ project that depends on `YCFirstTime`.
 | [06-reset.swift](06-reset.swift) | Debug "reset app state" action |
 | [07-testing-with-seams.swift](07-testing-with-seams.swift) | Unit-test helper injecting version + clock |
 | [08-objc-usage.m](08-objc-usage.m) | Objective-C call sites |
+| [09-last-execution-date.swift](09-last-execution-date.swift) | Display "last asked N days ago" using `lastExecutionDate(forKey:)` |

--- a/FAQ.md
+++ b/FAQ.md
@@ -58,6 +58,16 @@ if YCFirstTime.shared.blockWasExecuted("onboarding.v1") {
 
 Pure read. Ignores version and interval — it only answers "has this key ever fired?".
 
+## How do I display "last asked N days ago" for a rate-limited prompt?
+
+```swift
+if let lastAsked = YCFirstTime.shared.lastExecutionDate(forKey: "prompt.rating") {
+    label.text = "Last asked \(lastAsked.formatted(.relative(presentation: .numeric)))"
+}
+```
+
+`lastExecutionDate(forKey:)` returns `nil` for keys that have never run and the stored `Date` otherwise. Pure read — no side effects.
+
 ## How do I reset all state (for a "Reset app" debug menu)?
 
 ```swift

--- a/Sources/YCFirstTime/YCFirstTime.swift
+++ b/Sources/YCFirstTime/YCFirstTime.swift
@@ -38,6 +38,7 @@ private let kSecondsPerDay: TimeInterval = 86_400
 ///
 /// ### Inspection and reset
 /// - ``blockWasExecuted(_:)``
+/// - ``lastExecutionDate(forKey:)``
 /// - ``reset()``
 ///
 /// ### Testing seams
@@ -172,6 +173,20 @@ public final class YCFirstTime: NSObject, @unchecked Sendable {
     @objc(blockWasExecuted:)
     public func blockWasExecuted(_ key: String) -> Bool {
         alreadyExecuted(forKey: key, perVersion: false, everyXDays: 0)
+    }
+
+    /// Returns the timestamp of the most recent successful execution for `key`,
+    /// or `nil` if the key has never run.
+    ///
+    /// Useful for UIs that want to display "last asked N days ago" — the
+    /// library already stores this for interval math, so there's no reason to
+    /// track it twice.
+    ///
+    /// - Parameter key: A globally-unique identifier.
+    /// - Returns: The recorded `Date`, or `nil` for a key that has never run.
+    @objc(lastExecutionDateForKey:)
+    public func lastExecutionDate(forKey key: String) -> Date? {
+        info(forBlock: key)?.lastTime
     }
 
     /// Clears every recorded execution, in memory and on disk.

--- a/Tests/YCFirstTimeTests/YCFirstTimeTests.swift
+++ b/Tests/YCFirstTimeTests/YCFirstTimeTests.swift
@@ -227,6 +227,50 @@ final class YCFirstTimeTests: XCTestCase {
         XCTAssertTrue(sut.blockWasExecuted("k"), "blockWasExecuted must not consider version")
     }
 
+    // MARK: - lastExecutionDate
+
+    func test_lastExecutionDate_isNilBeforeAnyRun() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+
+        XCTAssertNil(sut.lastExecutionDate(forKey: "never-run"))
+    }
+
+    func test_lastExecutionDate_returnsStoredTimestamp() {
+        let fixed = Date(timeIntervalSince1970: 1_700_000_000)
+        let sut = YCFirstTime.makeForTest(version: "1.0", now: fixed)
+
+        sut.executeOnce({}, forKey: "k")
+
+        XCTAssertEqual(sut.lastExecutionDate(forKey: "k"), fixed)
+    }
+
+    func test_lastExecutionDate_updatesOnSubsequentRunsOfIntervalBlock() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        var now = start
+        let sut = YCFirstTime()
+        sut.versionProvider = { "1.0" }
+        sut.nowProvider = { now }
+
+        sut.executeOncePerInterval({}, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(sut.lastExecutionDate(forKey: "k"), start)
+
+        // Cross the interval; the block re-runs and the stored timestamp
+        // should advance to the new "now".
+        now = start.addingTimeInterval(2 * 86_400)
+        sut.executeOncePerInterval({}, forKey: "k", withDaysInterval: 1)
+        XCTAssertEqual(sut.lastExecutionDate(forKey: "k"), now)
+    }
+
+    func test_lastExecutionDate_isNilAfterReset() {
+        let sut = YCFirstTime.makeForTest(version: "1.0")
+        sut.executeOnce({}, forKey: "k")
+        XCTAssertNotNil(sut.lastExecutionDate(forKey: "k"))
+
+        sut.reset()
+
+        XCTAssertNil(sut.lastExecutionDate(forKey: "k"))
+    }
+
     // MARK: - reset
 
     func test_reset_clearsInMemoryState() {


### PR DESCRIPTION
Apps that show rate-limited prompts often want to display when the
prompt last fired ("last asked 3 days ago"). The library already
stores this timestamp for interval math; exposing it means callers
don't have to track it themselves.

- Public API:
    `lastExecutionDate(forKey:) -> Date?`
    @objc selector: `-[YCFirstTime lastExecutionDateForKey:]`
  Returns nil if the key has never run, otherwise the stored `Date`.
  Pure read — calling it does not mark anything as executed.
- Four tests: never-run returns nil; returns stored timestamp;
  advances after an interval re-run; returns nil after reset().
- CHANGELOG under [Unreleased], FAQ entry, Examples/09.
- Updated DocC Topics group under "Inspection and reset".

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK