### PR TITLE
Auto-publish to CocoaPods trunk on GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to CocoaPods
+
+# Triggers when a GitHub Release is published. The release's tag name must
+# match the version declared in YCFirstTime.podspec — the verification step
+# below fails the run otherwise, preventing trunk pushes that disagree with
+# the source of truth.
+#
+# Manual fallback: workflow_dispatch lets you re-run the publish for the
+# version currently in the podspec, without creating a new release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: pod trunk push
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Show environment
+        run: |
+          xcodebuild -version
+          pod --version
+
+      - name: Verify podspec version matches the release tag
+        # Skipped on workflow_dispatch (no GITHUB_REF_NAME tag context). On a
+        # release event GITHUB_REF_NAME is the tag (e.g. "2.0.0").
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          SPEC_VERSION=$(grep -E "spec\.version\s*=" YCFirstTime.podspec \
+            | head -1 \
+            | sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/")
+          echo "Release tag:    $TAG"
+          echo "Podspec version: $SPEC_VERSION"
+          if [ "$TAG" != "$SPEC_VERSION" ]; then
+            echo "::error::Release tag '$TAG' does not match podspec version '$SPEC_VERSION'. Bump the podspec on master first, then create the release."
+            exit 1
+          fi
+
+      - name: Lint podspec
+        # Same lint our CI runs on every push, repeated here as a last guard
+        # before the irreversible trunk push.
+        run: pod lib lint YCFirstTime.podspec --allow-warnings --skip-tests --fail-fast
+
+      - name: Push to CocoaPods trunk
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push YCFirstTime.podspec --allow-warnings --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,22 @@ The library is single-threaded per key. If you introduce concurrent access patte
 
 ## Releases
 
-Semantic versioning. Tag releases on `master` as `X.Y.Z`. After a tag is pushed, update the CocoaPods trunk (`pod trunk push YCFirstTime.podspec`) and the Swift Package Index picks up the tag automatically.
+Semantic versioning. The release flow is:
+
+1. Bump `spec.version` in `YCFirstTime.podspec` to `X.Y.Z` and promote the
+   `[Unreleased]` block in `CHANGELOG.md` to `[X.Y.Z]` — same commit, on master.
+2. Create a GitHub Release with tag `X.Y.Z` targeting `master`. Use the
+   `[X.Y.Z]` CHANGELOG block as the release body.
+3. The **Publish to CocoaPods** workflow (`.github/workflows/publish.yml`)
+   fires on the release, verifies the tag matches the podspec, lints, and
+   runs `pod trunk push`. Swift Package Index picks up the tag on its own.
+
+The publish workflow needs a one-time secret set on the repo: register a
+trunk session locally with `pod trunk register <email> "<name>"`, then copy
+the password line for `trunk.cocoapods.org` from `~/.netrc` into a GitHub
+repo secret named `COCOAPODS_TRUNK_TOKEN`.
+
+If you ever need to re-publish without cutting a new release, run the
+**Publish to CocoaPods** workflow manually via the Actions tab
+(workflow_dispatch). It uses whatever version is currently in
+`YCFirstTime.podspec` on `master`.


### PR DESCRIPTION
Manual `pod trunk push` from a developer Mac was failing with a local-cache parse error and is generally fragile (needs a logged-in trunk session, the right Ruby/gem versions, no stale spec cache). Move the publish to a clean macos-latest runner that reproduces the shape of our existing CI lint job.

Workflow lives at .github/workflows/publish.yml and:

- Triggers on `release: published`. Workflow_dispatch is supported as a manual fallback for re-publishing the current podspec version.
- Reads GITHUB_REF_NAME (the release tag) and asserts it matches `spec.version` in the podspec. Mismatched tag/version fails the job, preventing trunk pushes that contradict the source of truth.
- Re-runs `pod lib lint --allow-warnings --skip-tests --fail-fast` as a last guard before the irreversible trunk push.
- Calls `pod trunk push --allow-warnings --verbose` with COCOAPODS_TRUNK_TOKEN supplied via repo secret.

CONTRIBUTING.md now documents the full release flow: bump podspec + CHANGELOG → create GitHub Release → workflow does the rest. Includes the one-time setup for the COCOAPODS_TRUNK_TOKEN secret.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK

<!--
Keep this PR focused. Unrelated cleanup belongs in a separate PR.
-->

## Summary

<!-- 1–3 bullets: what this changes and why. -->

## Changes

<!-- Bulleted list of the notable diffs. -->

## Test plan

<!--
How did you verify this?
- [ ] `swift test` passes locally
- [ ] `pod lib lint YCFirstTime.podspec --allow-warnings` passes
- [ ] Added / updated tests
- [ ] Updated `///` doc comments for any changed public symbol
- [ ] Added a `CHANGELOG.md` entry under `[Unreleased]`
-->

## Persistence contract

<!--
Does this PR change any of:
- UserDefaults key ("YCFirstTime")
- sharedGroup constant
- YCFirstTimeObject class name
- "lastVersion" / "lastTime" coder keys

If yes, describe the migration plan. If no, delete this section.
-->
