### PR TITLE
Bump podspec to 2.1.0; promote [Unreleased] CHANGELOG block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-04-19
+
 ### Added
 
 - `lastExecutionDate(forKey:) -> Date?` — read-only accessor for the timestamp
@@ -78,7 +80,8 @@ against the same selectors.
 
 Initial CocoaPods releases. See commit history for details.
 
-[Unreleased]: https://github.com/fabioknoedt/YCFirstTime/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/fabioknoedt/YCFirstTime/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/fabioknoedt/YCFirstTime/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/fabioknoedt/YCFirstTime/releases/tag/2.0.0
 [1.2.0]: https://github.com/fabioknoedt/YCFirstTime/compare/1.1.4...1.2.0
 [1.1.4]: https://github.com/fabioknoedt/YCFirstTime/releases/tag/1.1.4

--- a/YCFirstTime.podspec
+++ b/YCFirstTime.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'YCFirstTime'
-  spec.version          = '2.0.0'
+  spec.version          = '2.1.0'
   spec.license          = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage         = 'https://github.com/fabioknoedt/YCFirstTime'
   spec.authors          = { 'Fabio Knoedt' => 'fabioknoedt@gmail.com' }


### PR DESCRIPTION
`lastExecutionDate(forKey:)` is a public API addition (already on master), which under semver bumps the minor: 2.0.0 → 2.1.0.

- YCFirstTime.podspec: spec.version 2.0.0 → 2.1.0.
- CHANGELOG.md: promote the [Unreleased] entry to a [2.1.0] section dated today; add the corresponding compare link in the footer.

Once merged, the publish flow is:

  1. Create a GitHub Release with tag 2.1.0 against master.
  2. The Publish to CocoaPods workflow fires automatically and runs `pod trunk push`. SPM users get 2.1.0 from the tag immediately.

Note that 2.0.0 is currently un-published on CocoaPods trunk. Cut a 2.0.0 release first (or just publish 2.1.0 — trunk doesn't require sequential pushes).

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK

<!--
Keep this PR focused. Unrelated cleanup belongs in a separate PR.
-->

## Summary

<!-- 1–3 bullets: what this changes and why. -->

## Changes

<!-- Bulleted list of the notable diffs. -->

## Test plan

<!--
How did you verify this?
- [ ] `swift test` passes locally
- [ ] `pod lib lint YCFirstTime.podspec --allow-warnings` passes
- [ ] Added / updated tests
- [ ] Updated `///` doc comments for any changed public symbol
- [ ] Added a `CHANGELOG.md` entry under `[Unreleased]`
-->

## Persistence contract

<!--
Does this PR change any of:
- UserDefaults key ("YCFirstTime")
- sharedGroup constant
- YCFirstTimeObject class name
- "lastVersion" / "lastTime" coder keys

If yes, describe the migration plan. If no, delete this section.
-->
