### PR TITLE
Replace static SwiftPM/Platform badges with live Swift Package Index ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/fabioknoedt/YCFirstTime/actions/workflows/ci.yml/badge.svg)](https://github.com/fabioknoedt/YCFirstTime/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/fabioknoedt/YCFirstTime/branch/master/graph/badge.svg)](https://codecov.io/gh/fabioknoedt/YCFirstTime)
-[![SwiftPM](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://swift.org/package-manager/)
+[![Swift versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffabioknoedt%2FYCFirstTime%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/fabioknoedt/YCFirstTime)
+[![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffabioknoedt%2FYCFirstTime%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/fabioknoedt/YCFirstTime)
 [![CocoaPods](https://img.shields.io/cocoapods/v/YCFirstTime.svg)](https://cocoapods.org/pods/YCFirstTime)
-[![Platform](https://img.shields.io/badge/platform-iOS%2015%2B-lightgrey.svg)](https://github.com/fabioknoedt/YCFirstTime)
 [![License](https://img.shields.io/github/license/fabioknoedt/YCFirstTime.svg)](LICENSE)
 
 Run Swift code once per install, once per app version, or once every N days. Persists to `UserDefaults`. `@objc`-compatible — works from Swift and Objective-C unchanged.


### PR DESCRIPTION
The previous SwiftPM and Platform badges were shields.io static
strings — they said the right thing but didn't reflect reality (no
verification that the package builds, no platform list pulled from
Package.swift). The Swift Package Index badges hit a live endpoint
that returns whatever SPI's most recent build run resolved, so:

- The Swift versions badge updates automatically when we declare new
  swift-tools-version values.
- The Platforms badge updates from `platforms:` in Package.swift —
  cheaper than maintaining a parallel string in the README.

Both badges link to the SPI package page, which doubles as the
hosted-DocC entry point.

Hold the merge until the SPI submission (PackageList#13309) is
accepted and the repo finishes its first build — until then the
endpoint returns an error and the badges render as unknown.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK