### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot configuration.
+#
+# Watches GitHub Actions only — the library has no runtime dependencies, and
+# Swift Package Manager isn't a Dependabot ecosystem for libraries (it would
+# only matter for an app consuming this package).
+#
+# Weekly cadence is right for a small project: noisy enough to surface
+# deprecations like #14 promptly, quiet enough that returning to a stack of
+# 30 PRs after a few months away never happens.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    labels:
+      - ci
+      - dependencies
+    groups:
+      # Bundle minor + patch version bumps into a single PR per week so the
+      # inbox doesn't fragment. Major bumps still come through as separate
+      # PRs because they may need code changes.
+      github-actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Set-and-forget addition before stepping away from the project for a
few months. When the next Node deprecation hits or codecov-action
v6 ships, Dependabot opens the PR, CI runs, and merging takes 30
seconds. Without this, returning to the project means digging
through a stack of action-deprecation warnings — exactly the
situation that created issue #14.

- Watches `github-actions` only; the library has no runtime
  dependencies, and SPM isn't a Dependabot ecosystem for libraries.
- Weekly cadence, Mondays. Loud enough to catch deprecations early,
  quiet enough to never accumulate.
- `open-pull-requests-limit: 5` caps the inbox.
- `commit-message.prefix: ci` keeps the existing commit-style.
- Minor/patch bumps grouped into one PR per week; major bumps stay
  separate so they get individual review (they sometimes need
  workflow surgery, e.g. v4→v5 inputs).

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK