### PR TITLE
Cover the default versionProvider closure (YCFirstTime.swift:79)

### DIFF
--- a/Tests/YCFirstTimeTests/YCFirstTimeTests.swift
+++ b/Tests/YCFirstTimeTests/YCFirstTimeTests.swift
@@ -229,6 +229,24 @@ final class YCFirstTimeTests: XCTestCase {
 
     // MARK: - lastExecutionDate
 
+    func test_defaultVersionProvider_invokesBundleLookup() {
+        // Every other test injects versionProvider via makeForTest, so the
+        // default closure (Bundle.main.object lookup at YCFirstTime.swift:79)
+        // never runs and the line shows uncovered.
+        //
+        // Construct a YCFirstTime directly so versionProvider stays at the
+        // init-provided default, then trigger saveExecution — that path
+        // unconditionally calls `versionProvider?()`, which executes the
+        // closure body and exercises the Bundle lookup.
+        let sut = YCFirstTime()
+
+        sut.executeOnce({}, forKey: "default-version-provider-coverage")
+
+        XCTAssertTrue(sut.blockWasExecuted("default-version-provider-coverage"))
+    }
+
+    // MARK: - lastExecutionDate
+
     func test_lastExecutionDate_isNilBeforeAnyRun() {
         let sut = YCFirstTime.makeForTest(version: "1.0")
 


### PR DESCRIPTION
Codecov flagged line 79 — the body of the default versionProvider
closure assigned in init() — as uncovered. Every existing test goes
through makeForTest, which immediately overrides versionProvider, so
the init-provided closure never runs.

Add test_defaultVersionProvider_invokesBundleLookup: constructs
YCFirstTime() directly (no provider override), then calls
executeOnce(...). saveExecution() invokes `versionProvider?()`
unconditionally, which executes the closure body and runs the
Bundle.main lookup whether it returns nil or a string.

The test asserts the block was marked executed, which only happens
if saveExecution ran end-to-end — proving the closure actually
fired, not just got assigned.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK