### PR TITLE
Drop labels from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: ci
-    labels:
-      - ci
-      - dependencies
     groups:
       # Bundle minor + patch version bumps into a single PR per week so the
       # inbox doesn't fragment. Major bumps still come through as separate


### PR DESCRIPTION
Dependabot opened PR #31 and warned: "The following labels could not
be found: ci, dependencies." The original config requested both
labels, but neither exists in the repo's label set. The PR ends up
in a `mergeable_state: blocked` because of this noise (CI itself
passes).

Two ways to fix this:

1. Create the two labels manually in repo Settings → Labels.
2. Remove the labels: block from the config and let Dependabot
   apply no labels by default.

Going with (2): this is a small repo with one maintainer; the
labels weren't doing real organizational work, just signaling
intent. The commit-message prefix (`ci`) already does that job in
the PR title.

If you ever want the labels back, just re-add the block here and
create matching labels in repo Settings.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK