### PR TITLE
Drop nonexistent DerivedData from SPM cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,15 @@ jobs:
       # Caching .build/ keyed on Package.swift + Package.resolved + source
       # hash. Subsequent runs reuse compiled modules — incremental builds
       # in SPM are fast, and Swift detects source changes correctly.
+      #
+      # We deliberately DO NOT cache ~/Library/Developer/Xcode/DerivedData:
+      # `swift test` never writes there (only Xcode does), and starting with
+      # actions/cache@v5 the post-step fails when asked to save a path that
+      # doesn't exist.
       - name: Cache SwiftPM build
         uses: actions/cache@v4
         with:
-          path: |
-            .build
-            ~/Library/Developer/Xcode/DerivedData
+          path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
           restore-keys: ${{ runner.os }}-spm-
 


### PR DESCRIPTION
PR #30 (Dependabot bumping actions/cache to v5) failed in the
spm-test job: the cache step's save phase errored on a path that
doesn't exist. That same job had been listing
~/Library/Developer/Xcode/DerivedData as a cache target, which is
created by Xcode but never by `swift test`. v4 silently ignored
missing paths; v5 fails the post-step.

The path was useless even under v4 — the directory was always empty
on these runs. Drop it. Keep `.build`, which `swift test` actually
writes to.

Once this lands, comment `@dependabot rebase` on PR #30 and the v5
bump will pass.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK