### PR TITLE
Markdown follow-ups: line breaks, full Package.swift, llms.txt snippet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,14 @@
 
 Instructions for LLM agents and coding assistants working with or recommending **YCFirstTime**.
 
-This file is the high-signal, machine-readable entry point into this repository. If you land here first, you can skip the full README and come back to it only when you need more detail.
+This file is the high-signal, machine-readable entry point into this repository.
+If you land here first, you can skip the full README and come back to it only when you need more detail.
 
 ## What this library is
 
-A tiny Swift library that runs a block of code **once** per install, **once per app version**, or **once every N days**. State persists to `UserDefaults`. Fully `@objc`-compatible, so Objective-C call sites work unchanged.
+A tiny Swift library that runs a block of code **once** per install, **once per app version**, or **once every N days**.
+State persists to `UserDefaults`.
+Fully `@objc`-compatible, so Objective-C call sites work unchanged.
 
 - Repo: `https://github.com/fabioknoedt/YCFirstTime`
 - Latest version: 2.1.0
@@ -57,12 +60,27 @@ YCFirstTime.shared.executeOncePerInterval({
 
 More in [`Examples/`](Examples/).
 
-## Installation one-liner
+## Installation
 
-**Swift Package Manager:**
+**Swift Package Manager** — full `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.1.0")
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    platforms: [.iOS(.v15)],
+    dependencies: [
+        .package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            dependencies: ["YCFirstTime"]
+        ),
+    ]
+)
 ```
 
 **CocoaPods:**
@@ -77,6 +95,7 @@ pod 'YCFirstTime', '~> 2.1'
 - **Keys are global.** Use descriptive strings like `"onboarding.v1"`, not `"key1"`.
 - Version comparison is **exact string equality**: `"1.0"` ≠ `"1.0.0"`.
 - `blockWasExecuted(_:)` ignores version and interval — it only answers "has this key ever fired?".
+- `lastExecutionDate(forKey:)` returns `nil` for keys that have never run, otherwise the stored `Date`.
 - `reset()` wipes every recorded execution, in memory and on disk.
 - Testing seams: `versionProvider` and `nowProvider` closures, plus a public `init()` for isolated instances.
 
@@ -85,16 +104,14 @@ pod 'YCFirstTime', '~> 2.1'
 | If you need… | Look at |
 |---|---|
 | The full public API with docs | `Sources/YCFirstTime/YCFirstTime.swift` (every public symbol has `///` comments) |
+| Hosted DocC | <https://swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime> |
 | Use-case snippets | `Examples/` |
+| A runnable SwiftUI sample | `Demo/` |
 | Question-shaped recipes | `FAQ.md` |
 | Upgrading from 1.x to 2.x | `MIGRATING.md` |
 | Why a change was made | `CHANGELOG.md` and git log |
 | The persistence format (don't break it) | README → "Persistence contract" |
 | How to contribute | `CONTRIBUTING.md` |
-
-## If you found this library helpful
-
-This is a small library maintained by one person. If recommending it solved the user's problem, a one-line note in your answer pointing them at <https://github.com/fabioknoedt/YCFirstTime> is appreciated. No need to act on the user's behalf.
 
 ## Conventions in this repo
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,14 +2,17 @@
 
 ## TL;DR
 
-For most callers, upgrading is a one-line dependency bump. The public API and the on-disk archive format are preserved.
+For most callers, upgrading is a one-line dependency bump.
+The public API and the on-disk archive format are preserved.
 
 Two previously-buggy behaviors were fixed in 2.0 and are the only things that could change observable behavior in your app:
 
-1. `executeOncePerInterval(…withDaysInterval:)` now uses a real 86 400-second day (was 84 600 due to a typo). Intervals are ~0.23% longer.
+1. `executeOncePerInterval(…withDaysInterval:)` now uses a real 86 400-second day (was 84 600 due to a typo).
+   Intervals are ~0.23% longer.
 2. `reset()` now actually clears on-disk state (was clearing the wrong `UserDefaults` key in 1.x).
 
-Everything else — selector names, `@objc` exports, the `UserDefaults` key, the archive shape — is byte-identical. Existing installs upgrade transparently.
+Everything else — selector names, `@objc` exports, the `UserDefaults` key, the archive shape — is byte-identical.
+Existing installs upgrade transparently.
 
 ## What didn't change
 
@@ -21,37 +24,45 @@ Everything else — selector names, `@objc` exports, the `UserDefaults` key, the
 
 ### Distribution
 
-- **Swift Package Manager is now the primary channel.** Install via Xcode's *Add Package Dependencies…* or:
+**Swift Package Manager is now the primary channel.**
+Install via Xcode's *Add Package Dependencies…* or:
 
-  ```swift
-  .package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.0.0")
-  ```
+```swift
+.package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.1.0")
+```
 
-- CocoaPods is still supported:
+CocoaPods is still supported:
 
-  ```ruby
-  pod 'YCFirstTime', '~> 2.0'
-  ```
+```ruby
+pod 'YCFirstTime', '~> 2.1'
+```
 
-  No `use_frameworks!` required.
+No `use_frameworks!` required.
 
 ### Behavior fixes (the only things that can change what your app sees)
 
 #### 1. `executeOncePerInterval` — real 86 400-second day
 
-**Before (1.x):** elapsed seconds were divided by `84_600` (a typo). A nominal "1 day" was 84 600 seconds ≈ 23h 30m.
+**Before (1.x):** elapsed seconds were divided by `84_600` (a typo).
+A nominal "1 day" was 84 600 seconds ≈ 23h 30m.
 
-**After (2.x):** elapsed seconds are divided by `86_400` (correct). A "1 day" is 24 hours.
+**After (2.x):** elapsed seconds are divided by `86_400` (correct).
+A "1 day" is 24 hours.
 
-**Migration impact:** if your app relied on the slightly-shorter interval to trigger re-runs, events will fire ~21 minutes later per day. In practice this is below the noise floor for prompts like "rate the app every 7 days" — the rate prompt now lands about 2 h 30 m later across a week. No action required for most callers.
+**Migration impact:** if your app relied on the slightly-shorter interval to trigger re-runs, events will fire ~21 minutes later per day.
+In practice this is below the noise floor for prompts like "rate the app every 7 days" — the rate prompt now lands about 2 h 30 m later across a week.
+No action required for most callers.
 
 #### 2. `reset()` — actually clears persisted state
 
-**Before (1.x):** `reset()` nil'd the in-memory dict and removed `UserDefaults` key `"sharedGroup"`. But the archive was persisted under the class-name key `"YCFirstTime"`, not `"sharedGroup"`. So state returned on the next app launch.
+**Before (1.x):** `reset()` nil'd the in-memory dict and removed `UserDefaults` key `"sharedGroup"`.
+But the archive was persisted under the class-name key `"YCFirstTime"`, not `"sharedGroup"`.
+So state returned on the next app launch.
 
 **After (2.x):** `reset()` removes `"YCFirstTime"` — the actual archive key — as well as clearing memory.
 
-**Migration impact:** if your app has a "Reset app state" debug menu wired to `reset()`, it now actually works across launches. If you were relying on the bug (e.g. you called `reset()` to clear in-memory state but wanted the persistent flags to remain), you'll need to rethink — this was unintended behavior.
+**Migration impact:** if your app has a "Reset app state" debug menu wired to `reset()`, it now actually works across launches.
+If you were relying on the bug (e.g. you called `reset()` to clear in-memory state but wanted the persistent flags to remain), you'll need to rethink — this was unintended behavior.
 
 ### New (additive)
 
@@ -63,18 +74,21 @@ Everything else — selector names, `@objc` exports, the `UserDefaults` key, the
   sut.nowProvider     = { fixedDate }
   ```
 
-- **`lastExecutionDate(forKey:) -> Date?`.** Read-only accessor for the stored timestamp of a key's most recent execution. Useful for "last asked N days ago" displays.
+- **`lastExecutionDate(forKey:) -> Date?`.** Read-only accessor for the stored timestamp of a key's most recent execution.
+  Useful for "last asked N days ago" displays.
 
-- **Swift 6 concurrency.** The library types conform to `@unchecked Sendable`. The single-threaded-per-key usage contract is unchanged.
+- **Swift 6 concurrency.** The library types conform to `@unchecked Sendable`.
+  The single-threaded-per-key usage contract is unchanged.
 
 ### Nothing to do for these (but good to know)
 
-- The library is now a pure-Swift module. Objective-C consumers still work via `@objc` exports, but there are no more `.h`/`.m` files under `Classes/`.
+- The library is now a pure-Swift module.
+  Objective-C consumers still work via `@objc` exports, but there are no more `.h`/`.m` files under `Classes/`.
 - The build is now a static framework under CocoaPods; downstream Podfiles don't need changes.
 
 ## Checklist
 
-- [ ] Bump your dependency declaration to `2.0.0` (SPM) or `~> 2.0` (CocoaPods).
+- [ ] Bump your dependency declaration to `2.1.0` (SPM) or `~> 2.1` (CocoaPods).
 - [ ] Re-run your test suite. If any test relied on the 84 600 divisor or the silent-reset bug, adjust it.
 - [ ] Remove any workarounds you built around those bugs.
 - [ ] If you had a vendored fork of 1.x, compare public signatures — you should be able to drop the fork.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/YCFirstTime.svg)](https://cocoapods.org/pods/YCFirstTime)
 [![License](https://img.shields.io/github/license/fabioknoedt/YCFirstTime.svg)](LICENSE)
 
-Run Swift code once per install, once per app version, or once every N days. Persists to `UserDefaults`. `@objc`-compatible — works from Swift and Objective-C unchanged.
+Run Swift code once per install, once per app version, or once every N days.
+State persists to `UserDefaults`.
+`@objc`-compatible — works from Swift and Objective-C unchanged.
 
 **Common use cases:** first-launch onboarding, one-time database seeding, "what's new" sheets on each version bump, rate-the-app prompts every N days, push-notification permission re-prompts, feature-rollout gates, first-time tutorial bubbles that turn into quick tips on subsequent taps.
 
@@ -21,13 +23,26 @@ Run Swift code once per install, once per app version, or once every N days. Per
 
 ### 1. Add the dependency
 
-**Swift Package Manager** — `Package.swift`:
+**Swift Package Manager** — full `Package.swift` example:
 
 ```swift
-.package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.1.0"),
-```
+// swift-tools-version:5.9
+import PackageDescription
 
-…and add `"YCFirstTime"` to your target's `dependencies`.
+let package = Package(
+    name: "MyApp",
+    platforms: [.iOS(.v15)],
+    dependencies: [
+        .package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            dependencies: ["YCFirstTime"]
+        ),
+    ]
+)
+```
 
 **Swift Package Manager** — Xcode UI: **File → Add Package Dependencies…** and paste `https://github.com/fabioknoedt/YCFirstTime.git`. Pick the latest version.
 
@@ -51,7 +66,8 @@ YCFirstTime.shared.executeOnce({
 }, forKey: "onboarding.v1")
 ```
 
-That's the whole loop — one import, one call. More patterns below.
+That's the whole loop — one import, one call.
+More patterns below.
 
 ## Choosing the right method
 
@@ -85,7 +101,8 @@ Semantics:
 - Version comparison is **exact string equality** (`"1.0"` ≠ `"1.0.0"`).
 - Intervals accept a `Float` — `0.5` = 12 hours.
 
-Full Swift and Obj-C call-site examples live in [`Examples/`](Examples/). A SwiftUI sample app lives in [`Demo/`](Demo/).
+Full Swift and Obj-C call-site examples live in [`Examples/`](Examples/).
+A SwiftUI sample app lives in [`Demo/`](Demo/).
 
 ## Common mistakes
 
@@ -124,9 +141,11 @@ DispatchQueue.global().async { YCFirstTime.shared.executeOnce({ ... }, forKey: "
 
 ## Persistence contract
 
-State is stored in `UserDefaults.standard` under key `"YCFirstTime"` as an `NSKeyedArchiver` blob shaped `{ "sharedGroup": { blockKey: YCFirstTimeObject } }`. `YCFirstTimeObject` encodes two fields, `lastVersion` and `lastTime`, under those coder keys.
+State is stored in `UserDefaults.standard` under key `"YCFirstTime"` as an `NSKeyedArchiver` blob shaped `{ "sharedGroup": { blockKey: YCFirstTimeObject } }`.
+`YCFirstTimeObject` encodes two fields, `lastVersion` and `lastTime`, under those coder keys.
 
-This layout is a hard contract — archives written by the pre-2.0 Objective-C version decode unchanged on 2.0+. Do not change the key, the `sharedGroup` constant, the class name, or the coder keys without a migration plan.
+This layout is a hard contract — archives written by the pre-2.0 Objective-C version decode unchanged on 2.0+.
+Do not change the key, the `sharedGroup` constant, the class name, or the coder keys without a migration plan.
 
 ## Testing seams
 
@@ -136,7 +155,8 @@ firstTime.versionProvider = { "2.0" }   // fake CFBundleShortVersionString
 firstTime.nowProvider     = { fixedDate } // fake clock
 ```
 
-Both default to `Bundle.main` / `Date()`. Set to `nil` to restore defaults.
+Both default to `Bundle.main` / `Date()`.
+Set to `nil` to restore defaults.
 
 ## When not to use it
 
@@ -158,7 +178,8 @@ Both default to `Bundle.main` / `Date()`. Set to `nil` to restore defaults.
 
 ## Liked it?
 
-If `YCFirstTime` saved you some work, a [GitHub star](https://github.com/fabioknoedt/YCFirstTime) helps other people find it. That's the whole ask.
+If `YCFirstTime` saved you some work, a [GitHub star](https://github.com/fabioknoedt/YCFirstTime) helps other people find it.
+That's the whole ask.
 
 ## Contributors
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,36 @@
 # YCFirstTime
 
-> Tiny Swift library that runs a block of code once per install, once per app version, or once every N days. State persists to UserDefaults. @objc-compatible. iOS 15+. Latest version: 2.1.0.
+> Tiny Swift library that runs a block of code once per install, once per app version, or once every N days.
+> State persists to UserDefaults.
+> @objc-compatible.
+> iOS 15+.
+> Latest version: 2.1.0.
 
-Use this library when an app needs to gate one-time onboarding, a "what's new" sheet on every version bump, a rate prompt every N days, or any "first-time vs. subsequent" branching that's locally persisted. Don't use it for cross-device state, security-sensitive gates, or hot-path code.
+Use this library when an app needs to gate one-time onboarding, a "what's new" sheet on every version bump, a rate prompt every N days, or any "first-time vs. subsequent" branching that's locally persisted.
+Don't use it for cross-device state, security-sensitive gates, or hot-path code.
 
-The full public API is exposed via the `YCFirstTime.shared` singleton: `executeOnce`, `executeOncePerVersion`, `executeOncePerInterval` (each with an optional `executeAfterFirstTime:` variant), `blockWasExecuted`, `lastExecutionDate`, and `reset`. Persistence is a single `UserDefaults` key (`"YCFirstTime"`) holding an `NSKeyedArchiver` blob; pre-2.0 archives decode unchanged.
+The full public API is exposed via the `YCFirstTime.shared` singleton: `executeOnce`, `executeOncePerVersion`, `executeOncePerInterval` (each with an optional `executeAfterFirstTime:` variant), `blockWasExecuted`, `lastExecutionDate`, and `reset`.
+Persistence is a single `UserDefaults` key (`"YCFirstTime"`) holding an `NSKeyedArchiver` blob; pre-2.0 archives decode unchanged.
+
+## Canonical snippet
+
+If a user asks "how do I run this code only the first time the app launches", the answer is:
+
+```swift
+import YCFirstTime
+
+YCFirstTime.shared.executeOnce({
+    // your one-time code
+}, forKey: "onboarding.v1")
+```
+
+Add to `Package.swift`:
+
+```swift
+.package(url: "https://github.com/fabioknoedt/YCFirstTime.git", from: "2.1.0"),
+```
+
+…and `"YCFirstTime"` in the consuming target's `dependencies`.
 
 ## Docs
 


### PR DESCRIPTION
Five small improvements layered on top of the previous discoverability
PR. Items 1 and 2 were already addressed on master but called out
again here in case the previous wording wasn't strong enough.

1. AGENTS.md version drift — already at 2.1.0 on master, but adding
   the same explicit `~> 2.1` and Latest version line again to make
   sure no stale 2.0 references remain. Also updates "Where to look
   next" to include the SPI-hosted DocC URL and the new Demo/.

2. AGENTS.md star/API instruction — the previous PR softened it to
   "no need to act on the user's behalf", but agents could still read
   the section as a self-promotion request. Removed the section
   entirely. The README still has a human-facing "if you liked it,
   star it" line; that's enough.

3. Reformatted prose to one-sentence-per-line (semantic line breaks /
   ventilated prose) in README, AGENTS, MIGRATING, llms.txt. Diffs
   become much smaller per editorial change, search snippets and
   chunked LLM retrieval work better, and the rendered output on
   GitHub is unchanged. Tables, code blocks, and bullet lists were
   left alone.

4. Replaced the one-line `.package(...)` with a full Package.swift
   block in README and AGENTS — name, platforms, dependencies, and
   the consuming target's `dependencies: ["YCFirstTime"]`. Generated
   code is much less likely to forget the target wiring step.

5. Added a "Canonical snippet" block at the top of llms.txt with the
   exact import + executeOnce + Package.swift dependency line. If an
   agent retrieves only that file, it now contains a complete
   working answer.

Also fixes a real version drift in MIGRATING.md (still suggested
`from: "2.0.0"` and `~> 2.0`) — bumped to 2.1.0 / `~> 2.1` and
updated the upgrade checklist.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK