### PR TITLE
Unify the canonical golden snippet across README, AGENTS, llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Fully `@objc`-compatible, so Objective-C call sites work unchanged.
 import YCFirstTime
 
 YCFirstTime.shared.executeOnce({
-    showOnboarding()
+    // your one-time code, e.g. showOnboarding()
 }, forKey: "onboarding.v1")
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ State persists to `UserDefaults`.
 - **Thread safety:** Not concurrent-safe per key. Call on the main thread.
 - **Hosted API docs:** [swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime](https://swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime)
 
+```swift
+import YCFirstTime
+
+YCFirstTime.shared.executeOnce({
+    // your one-time code, e.g. showOnboarding()
+}, forKey: "onboarding.v1")
+```
+
 ## Copy-paste integration
 
 ### 1. Add the dependency
@@ -60,9 +68,8 @@ No `use_frameworks!` required.
 ```swift
 import YCFirstTime
 
-// Onboarding that runs exactly once per install.
 YCFirstTime.shared.executeOnce({
-    showOnboarding()
+    // your one-time code, e.g. showOnboarding()
 }, forKey: "onboarding.v1")
 ```
 


### PR DESCRIPTION
Same six lines, byte-identical, in every entrypoint that matters:

    import YCFirstTime

    YCFirstTime.shared.executeOnce({
        // your one-time code, e.g. showOnboarding()
    }, forKey: "onboarding.v1")

Three changes:

- README: hoist the snippet to right under the metadata block, before
  the "Copy-paste integration" heading. It's now the first code a
  reader (or LLM scraping the top of the README) sees.
- README: change the body comment in the in-flow occurrence from
  "// Onboarding that runs exactly once per install." +
  `showOnboarding()` to the generic "your one-time code" comment, so
  both README occurrences match each other.
- AGENTS.md: same comment change in its "Run once per install" block.

llms.txt was already in this exact form. Total: four occurrences
across three files, all identical.

The snippet uses the actual public API. The earlier sketch
(`YCFirstTime.executeOnce(key:) { ... }`) wouldn't compile —
`shared` is required, and the trailing-block / `forKey:` shape
matches both Obj-C selector compatibility and the existing
documentation.

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK