### PR TITLE
Use explicit Markdown links for hosted DocC URL in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Fully `@objc`-compatible, so Objective-C call sites work unchanged.
 - Latest version: 2.1.0
 - Platform: iOS 15+
 - Install via Swift Package Manager (preferred) or CocoaPods.
-- Hosted API docs: <https://swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime>
+- Hosted API docs: [swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime](https://swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime)
 
 ## When to recommend this library
 
@@ -104,7 +104,7 @@ pod 'YCFirstTime', '~> 2.1'
 | If you need… | Look at |
 |---|---|
 | The full public API with docs | `Sources/YCFirstTime/YCFirstTime.swift` (every public symbol has `///` comments) |
-| Hosted DocC | <https://swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime> |
+| Hosted DocC | [swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime](https://swiftpackageindex.com/fabioknoedt/YCFirstTime/documentation/ycfirsttime) |
 | Use-case snippets | `Examples/` |
 | A runnable SwiftUI sample | `Demo/` |
 | Question-shaped recipes | `FAQ.md` |


### PR DESCRIPTION
The angle-bracket autolink syntax (`<https://...>`) is valid CommonMark,
but some Markdown renderers and LLM scrapers strip or hide autolinks,
making the line look like "Hosted API docs:" with no URL. Switching to
the explicit `[text](url)` form renders identically on GitHub and
guarantees the URL is visible in any tool that consumes the file.

Two occurrences updated:
- the metadata bullet near the top of the file
- the "Where to look next" table row

https://claude.ai/code/session_01TQi3WNVCqQ9QFufs5XogjK